### PR TITLE
Fixed computation of timestamp

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = { version = "1.0", default_features = false }
 
 # perform requests to the internet
-reqwest = {version="*", features = ["gzip"]}
+reqwest = {version="0.11", features = ["gzip"]}
 reqwest-retry = "*"
 reqwest-middleware = "*"
 
@@ -44,6 +44,9 @@ tinytemplate = { version = "1.1", optional = true }
 itertools = { version = "*", optional = true }
 num-format = { version = "*", optional = true }
 simple_logger = { version = "*", optional = true }
+
+[dev-dependencies]
+tokio = {version="1.0", features=["rt", "macros", "rt-multi-thread"]}
 
 [features]
 build-binary = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,10 +45,6 @@ itertools = { version = "*", optional = true }
 num-format = { version = "*", optional = true }
 simple_logger = { version = "*", optional = true }
 
-[dev-dependencies]
-tokio = {version="1.0", features=["rt", "macros", "rt-multi-thread"]}
-itertools = "*"
-
 [features]
 build-binary = [
     "clap",

--- a/src/aircraft.rs
+++ b/src/aircraft.rs
@@ -153,7 +153,7 @@ pub async fn etl_aircrafts(client: Option<&fs_s3::ContainerClient>) -> Result<()
 
 pub async fn read(
     date: Date,
-    client: Option<&fs_s3::ContainerClient>,
+    client: Option<&dyn BlobStorageProvider>,
 ) -> Result<Aircrafts, String> {
     let path = file_path(date);
     let data = match client {

--- a/src/bin/etl_legs.rs
+++ b/src/bin/etl_legs.rs
@@ -319,9 +319,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
     });
 
     let _ = futures::stream::iter(tasks)
-        .buffered(20)
-        .try_collect::<Vec<_>>()
-        .await?;
+        .buffered(50)
+        .collect::<Vec<_>>()
+        .await;
 
     aggregate(private_jets, &models, &airports, client.unwrap()).await
 }

--- a/src/bin/etl_legs.rs
+++ b/src/bin/etl_legs.rs
@@ -43,7 +43,7 @@ struct Metadata {
 }
 
 async fn write_json(
-    client: &impl BlobStorageProvider,
+    client: &dyn BlobStorageProvider,
     d: impl Serialize,
     key: &str,
 ) -> Result<(), Box<dyn Error>> {
@@ -53,11 +53,11 @@ async fn write_json(
     Ok(client.put(key, bytes).await?)
 }
 
-async fn write_csv<B: BlobStorageProvider>(
+async fn write_csv(
     items: impl Iterator<Item = impl Serialize>,
     key: &str,
-    client: &B,
-) -> Result<(), B::Error> {
+    client: &dyn BlobStorageProvider,
+) -> Result<(), std::io::Error> {
     let mut wtr = csv::Writer::from_writer(vec![]);
     for leg in items {
         wtr.serialize(leg).unwrap()
@@ -106,7 +106,7 @@ async fn write(
     icao_number: &Arc<str>,
     month: time::Date,
     legs: impl Iterator<Item = impl Serialize>,
-    client: &impl BlobStorageProvider,
+    client: &dyn BlobStorageProvider,
 ) -> Result<(), Box<dyn Error>> {
     let key = format!(
         "{DATABASE}icao_number={icao_number}/month={}/data.csv",
@@ -121,7 +121,7 @@ async fn write(
 async fn read<D: DeserializeOwned>(
     icao_number: &Arc<str>,
     month: time::Date,
-    client: &impl BlobStorageProvider,
+    client: &dyn BlobStorageProvider,
 ) -> Result<Vec<D>, Box<dyn Error>> {
     let key = format!(
         "{DATABASE}icao_number={icao_number}/month={}/data.csv",
@@ -170,7 +170,7 @@ async fn etl_task(
     private_jets: &HashMap<Arc<str>, aircraft::Aircraft>,
     models: &AircraftModels,
     airports: &[Airport],
-    client: Option<&flights::fs_s3::ContainerClient>,
+    client: Option<&dyn BlobStorageProvider>,
 ) -> Result<(), Box<dyn Error>> {
     // extract
     let positions = flights::month_positions(month, &icao_number, client).await?;
@@ -190,7 +190,7 @@ async fn aggregate(
     private_jets: Vec<aircraft::Aircraft>,
     models: &AircraftModels,
     airports: &[Airport],
-    client: &flights::fs_s3::ContainerClient,
+    client: &dyn BlobStorageProvider,
 ) -> Result<(), Box<dyn Error>> {
     let private_jets = private_jets
         .into_iter()
@@ -301,7 +301,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     todo.sort_unstable_by_key(|(icao, date)| (date, icao));
     log::info!("todo     : {}", todo.len());
 
-    let client = Some(&client);
+    let client = Some(&client as &dyn BlobStorageProvider);
     let relevant_jets = &relevant_jets;
     let models = &models;
     let airports = &airports;

--- a/src/bin/etl_positions.rs
+++ b/src/bin/etl_positions.rs
@@ -71,7 +71,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .collect::<HashSet<_>>();
     log::info!("required : {}", required.len());
 
-    let completed = existing_months_positions(&client).await?;
+    let completed = HashSet::new(); //existing_months_positions(&client).await?;
     log::info!("completed: {}", completed.len());
     let mut todo = required.difference(&completed).collect::<Vec<_>>();
     todo.sort_unstable_by_key(|(icao, date)| (date, icao));
@@ -83,7 +83,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     futures::stream::iter(tasks)
         // limit concurrent tasks
-        .buffered(10)
+        .buffered(200)
         // continue if error
         .map(|r| {
             if let Err(e) = r {

--- a/src/bin/etl_positions.rs
+++ b/src/bin/etl_positions.rs
@@ -71,7 +71,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .collect::<HashSet<_>>();
     log::info!("required : {}", required.len());
 
-    let completed = HashSet::new(); //existing_months_positions(&client).await?;
+    let completed = existing_months_positions(&client).await?;
     log::info!("completed: {}", completed.len());
     let mut todo = required.difference(&completed).collect::<Vec<_>>();
     todo.sort_unstable_by_key(|(icao, date)| (date, icao));
@@ -83,7 +83,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     futures::stream::iter(tasks)
         // limit concurrent tasks
-        .buffered(200)
+        .buffered(10)
         // continue if error
         .map(|r| {
             if let Err(e) = r {

--- a/src/bin/period.rs
+++ b/src/bin/period.rs
@@ -93,11 +93,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
         }
         (Backend::Remote, _, _) => Some(flights::fs_s3::anonymous_client().await),
     };
+    let client = client.as_ref().map(|x| x as &dyn BlobStorageProvider);
 
     // load datasets to memory
     let owners = load_owners()?;
     let aircraft_owners = load_aircraft_owners()?;
-    let aircrafts = load_aircrafts(client.as_ref()).await?;
+    let aircrafts = aircraft::read(date!(2023 - 11 - 06), client).await?;
 
     let from = cli.from;
     let to = cli.to.unwrap_or(time::OffsetDateTime::now_utc().date());

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -7,11 +7,10 @@ static ROOT: &'static str = "database/";
 /// An object that can be used to get and put blobs.
 #[async_trait]
 pub trait BlobStorageProvider {
-    type Error: std::error::Error + Send + Sync + 'static;
-    async fn maybe_get(&self, blob_name: &str) -> Result<Option<Vec<u8>>, Self::Error>;
-    async fn put(&self, blob_name: &str, contents: Vec<u8>) -> Result<(), Self::Error>;
-    async fn list(&self, prefix: &str) -> Result<Vec<String>, Self::Error>;
-    async fn delete(&self, blob_name: &str) -> Result<(), Self::Error>;
+    async fn maybe_get(&self, blob_name: &str) -> Result<Option<Vec<u8>>, std::io::Error>;
+    async fn put(&self, blob_name: &str, contents: Vec<u8>) -> Result<(), std::io::Error>;
+    async fn list(&self, prefix: &str) -> Result<Vec<String>, std::io::Error>;
+    async fn delete(&self, blob_name: &str) -> Result<(), std::io::Error>;
 
     fn can_put(&self) -> bool;
 }
@@ -21,10 +20,8 @@ pub struct LocalDisk;
 
 #[async_trait]
 impl BlobStorageProvider for LocalDisk {
-    type Error = std::io::Error;
-
     #[must_use]
-    async fn maybe_get(&self, blob_name: &str) -> Result<Option<Vec<u8>>, Self::Error> {
+    async fn maybe_get(&self, blob_name: &str) -> Result<Option<Vec<u8>>, std::io::Error> {
         let path = PathBuf::from(ROOT).join(Path::new(blob_name));
         if path.try_exists()? {
             Ok(Some(std::fs::read(path)?))
@@ -34,7 +31,7 @@ impl BlobStorageProvider for LocalDisk {
     }
 
     #[must_use]
-    async fn put(&self, blob_name: &str, contents: Vec<u8>) -> Result<(), Self::Error> {
+    async fn put(&self, blob_name: &str, contents: Vec<u8>) -> Result<(), std::io::Error> {
         let path = PathBuf::from(ROOT).join(Path::new(blob_name));
         let mut dir = path.clone();
         dir.pop();
@@ -44,12 +41,12 @@ impl BlobStorageProvider for LocalDisk {
     }
 
     #[must_use]
-    async fn list(&self, _prefix: &str) -> Result<Vec<String>, Self::Error> {
+    async fn list(&self, _prefix: &str) -> Result<Vec<String>, std::io::Error> {
         todo!()
     }
 
     #[must_use]
-    async fn delete(&self, _prefix: &str) -> Result<(), Self::Error> {
+    async fn delete(&self, _prefix: &str) -> Result<(), std::io::Error> {
         todo!()
     }
 
@@ -58,29 +55,11 @@ impl BlobStorageProvider for LocalDisk {
     }
 }
 
-#[derive(Debug)]
-pub enum Error<F: std::error::Error + Send, E: std::error::Error + Send> {
-    /// An error originating from trying to read from source
-    Fetch(F),
-    /// An error originating from trying to read or write data from/to backend
-    Backend(E),
-}
-
-impl<F: std::error::Error + Send, E: std::error::Error + Send> std::error::Error for Error<F, E> {}
-
-impl<F: std::error::Error + Send, E: std::error::Error + Send> std::fmt::Display for Error<F, E> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Fetch(e) => std::fmt::Display::fmt(&e, f),
-            Self::Backend(e) => std::fmt::Display::fmt(&e, f),
-        }
-    }
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CacheAction {
     ReadFetchWrite,
     ReadFetch,
+    FetchWrite,
 }
 
 impl CacheAction {
@@ -102,32 +81,71 @@ pub async fn cached<E, P, F>(
     fetch: F,
     provider: &P,
     action: CacheAction,
-) -> Result<Vec<u8>, Error<E, P::Error>>
+) -> Result<Vec<u8>, std::io::Error>
 where
-    E: std::error::Error + Send,
+    E: std::error::Error + Send + Sync + 'static,
     F: futures::Future<Output = Result<Vec<u8>, E>>,
     P: BlobStorageProvider,
 {
-    log::info!("Fetch {blob_name}");
-    if let Some(data) = provider
-        .maybe_get(blob_name)
-        .await
-        .map_err(|e| Error::Backend(e))?
-    {
-        log::info!("{blob_name} - cache hit");
-        Ok(data)
-    } else {
-        log::info!("{blob_name} - cache miss");
-        let contents = fetch.await.map_err(|e| Error::Fetch(e))?;
-        if action == CacheAction::ReadFetch || !provider.can_put() {
-            log::info!("{blob_name} - cache do not write");
-            return Ok(contents);
-        };
-        provider
-            .put(blob_name, contents.clone())
-            .await
-            .map_err(|e| Error::Backend(e))?;
-        log::info!("{blob_name} - cache write");
-        Ok(contents)
+    match action {
+        CacheAction::FetchWrite => miss(blob_name, fetch, provider, action).await,
+        _ => {
+            log::info!("Fetch {blob_name}");
+            if let Some(data) = provider.maybe_get(blob_name).await? {
+                log::info!("{blob_name} - cache hit");
+                Ok(data)
+            } else {
+                miss(blob_name, fetch, provider, action).await
+            }
+        }
     }
+}
+
+/// Writes the result of `fetch` into `provider`.
+/// Returns the result of fetch.
+/// # Implementation
+/// This function is idempotent and pure.
+async fn miss<E, P, F>(
+    blob_name: &str,
+    fetch: F,
+    provider: &P,
+    action: CacheAction,
+) -> Result<Vec<u8>, std::io::Error>
+where
+    E: std::error::Error + Send + Sync + 'static,
+    F: futures::Future<Output = Result<Vec<u8>, E>>,
+    P: BlobStorageProvider,
+{
+    log::info!("{blob_name} - cache miss");
+    let contents = fetch.await.map_err(std::io::Error::other)?;
+    if action == CacheAction::ReadFetch || !provider.can_put() {
+        log::info!("{blob_name} - cache do not write");
+        return Ok(contents);
+    };
+    provider.put(blob_name, contents.clone()).await?;
+    log::info!("{blob_name} - cache write");
+    Ok(contents)
+}
+
+/// * read from remote
+/// * if not found and can't write to remote => read disk and write to disk
+/// * if not found and can write to remote => fetch and write
+pub(crate) async fn cached_call<F: futures::Future<Output = Result<Vec<u8>, std::io::Error>>>(
+    blob_name: &str,
+    fetch: F,
+    action: crate::fs::CacheAction,
+    client: Option<&impl BlobStorageProvider>,
+) -> Result<Vec<u8>, std::io::Error> {
+    let Some(client) = client else {
+        return Ok(crate::fs::cached(&blob_name, fetch, &crate::fs::LocalDisk, action).await?);
+    };
+
+    let Some(data) = client.maybe_get(blob_name).await? else {
+        if !client.can_put() {
+            return crate::fs::cached(&blob_name, fetch, &crate::fs::LocalDisk, action).await;
+        } else {
+            return crate::fs::cached(&blob_name, fetch, client, action).await;
+        };
+    };
+    Ok(data)
 }

--- a/src/icao_to_trace.rs
+++ b/src/icao_to_trace.rs
@@ -128,6 +128,21 @@ async fn globe_history_cached(
     Ok(fs_s3::cached_call(&blob_name, fetch, action, client).await?)
 }
 
+fn compute_trace(data: &[u8]) -> Result<(f64, Vec<serde_json::Value>), std::io::Error> {
+    let mut value = serde_json::from_slice::<serde_json::Value>(&data)?;
+    let Some(obj) = value.as_object_mut() else {
+        return Ok((0.0, vec![]));
+    };
+    let timestamp = obj.get("timestamp").unwrap().as_f64().unwrap();
+    let Some(obj) = obj.get_mut("trace") else {
+        return Ok((0.0, vec![]));
+    };
+    let Some(trace) = obj.as_array_mut() else {
+        return Ok((0.0, vec![]));
+    };
+    Ok((timestamp, std::mem::take(trace)))
+}
+
 /// Returns the trace of the icao number of a given day from https://adsbexchange.com.
 /// * `icao` must be lowercased
 /// * `date` must be a valid ISO8601 date in format `yyyy-mm-dd` and cannot be today.
@@ -140,24 +155,46 @@ async fn globe_history_cached(
 /// # Implementation
 /// Because these are historical values, this function caches them the first time it is used
 /// by the two arguments
-pub async fn trace_cached(
+async fn trace_cached(
     icao: &str,
     date: &time::Date,
     client: Option<&fs_s3::ContainerClient>,
-) -> Result<Vec<serde_json::Value>, std::io::Error> {
-    let data = globe_history_cached(icao, date, client).await?;
+) -> Result<(f64, Vec<serde_json::Value>), std::io::Error> {
+    compute_trace(&globe_history_cached(icao, date, client).await?)
+}
 
-    let mut value = serde_json::from_slice::<serde_json::Value>(&data)?;
-    let Some(obj) = value.as_object_mut() else {
-        return Ok(vec![]);
-    };
-    let Some(obj) = obj.get_mut("trace") else {
-        return Ok(vec![]);
-    };
-    let Some(trace) = obj.as_array_mut() else {
-        return Ok(vec![]);
-    };
-    Ok(std::mem::take(trace))
+fn compute_positions(start_trace: (f64, Vec<serde_json::Value>)) -> impl Iterator<Item = Position> {
+    use time::ext::NumericalDuration;
+
+    let (start, trace) = start_trace;
+    let start = OffsetDateTime::from_unix_timestamp(start as i64).unwrap();
+
+    trace.into_iter().filter_map(move |entry| {
+        let delta = entry[0].as_f64().unwrap().seconds();
+        let datetime = start + delta;
+        let latitude = entry[1].as_f64().unwrap();
+        let longitude = entry[2].as_f64().unwrap();
+        entry[3]
+            .as_str()
+            .and_then(|x| {
+                (x == "ground").then_some(Position {
+                    datetime,
+                    latitude,
+                    longitude,
+                    altitude: None,
+                })
+            })
+            .or_else(|| {
+                entry[3].as_f64().and_then(|altitude| {
+                    Some(Position {
+                        datetime,
+                        latitude,
+                        longitude,
+                        altitude: Some(altitude),
+                    })
+                })
+            })
+    })
 }
 
 /// Returns an iterator of [`Position`] over the trace of `icao` on day `date` according
@@ -167,38 +204,9 @@ pub async fn positions(
     date: time::Date,
     client: Option<&fs_s3::ContainerClient>,
 ) -> Result<impl Iterator<Item = Position>, std::io::Error> {
-    use time::ext::NumericalDuration;
     trace_cached(icao_number, &date, client)
         .await
-        .map(move |trace| {
-            trace.into_iter().filter_map(move |entry| {
-                let time_seconds = entry[0].as_f64().unwrap();
-                let time = time::Time::MIDNIGHT + time_seconds.seconds();
-                let datetime = OffsetDateTime::new_utc(date.clone(), time);
-                let latitude = entry[1].as_f64().unwrap();
-                let longitude = entry[2].as_f64().unwrap();
-                entry[3]
-                    .as_str()
-                    .and_then(|x| {
-                        (x == "ground").then_some(Position {
-                            datetime,
-                            latitude,
-                            longitude,
-                            altitude: None,
-                        })
-                    })
-                    .or_else(|| {
-                        entry[3].as_f64().and_then(|altitude| {
-                            Some(Position {
-                                datetime,
-                                latitude,
-                                longitude,
-                                altitude: Some(altitude),
-                            })
-                        })
-                    })
-            })
-        })
+        .map(compute_positions)
 }
 
 pub(crate) async fn cached_aircraft_positions(
@@ -230,3 +238,24 @@ pub(crate) async fn cached_aircraft_positions(
 }
 
 pub use crate::trace_month::*;
+
+#[cfg(test)]
+mod test {
+    use time::macros::date;
+
+    use super::*;
+
+    /// Compare against https://globe.adsbexchange.com/?icao=45860d&showTrace=2019-01-04&leg=1
+    #[tokio::test]
+    async fn work() {
+        let data = globe_history("45860d", &date!(2019 - 01 - 04))
+            .await
+            .unwrap();
+        let first = compute_positions(compute_trace(&data).unwrap())
+            .next()
+            .unwrap();
+        assert_eq!(first.datetime.hour(), 6);
+        assert_eq!(first.datetime.minute(), 54);
+        assert_eq!(first.grounded(), true);
+    }
+}

--- a/src/icao_to_trace.rs
+++ b/src/icao_to_trace.rs
@@ -125,7 +125,7 @@ async fn globe_history_cached(
     let action = fs::CacheAction::from_date(&date);
     let fetch = globe_history(&icao, date);
 
-    Ok(fs_s3::cached_call(&blob_name, fetch, action, client).await?)
+    Ok(fs::cached_call(&blob_name, fetch, action, client).await?)
 }
 
 fn compute_trace(data: &[u8]) -> Result<(f64, Vec<serde_json::Value>), std::io::Error> {

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -1,6 +1,6 @@
 use std::error::Error;
 
-use flights::Leg;
+use flights::{BlobStorageProvider, Leg};
 use time::{
     macros::{date, datetime},
     Date,
@@ -71,7 +71,7 @@ async fn legs(
     from: Date,
     to: Date,
     icao_number: &str,
-    client: Option<&flights::fs_s3::ContainerClient>,
+    client: Option<&dyn BlobStorageProvider>,
 ) -> Result<Vec<Leg>, Box<dyn Error>> {
     let positions = flights::aircraft_positions(from, to, icao_number, client).await?;
     Ok(flights::legs(positions.into_iter()))


### PR DESCRIPTION
This was an error that impacted most calculations.

The root issue was that the timestamp of a trace was being computed since midnight, when it should be computed from a specific timestamp available in the trace's json.

Added regression test.

Also improved the ergonomics of the library.